### PR TITLE
Improve vibration support and cues

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A React Native Expo app that provides compass functionality with background audi
 - Optional offset calibration for using the phone at an angle (including in a pocket)
 - No location tracking required
 - Accessibility-friendly design
-- Optional vibration mode when facing north
+- Optional vibration alerts when facing north (directional sounds still play)
 
 ## Setup Instructions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "buffer": "^6.0.3",
         "expo": "^53.0.0",
         "expo-av": "~15.1.5",
+        "expo-battery": "~9.1.4",
         "expo-build-properties": "~0.14.6",
         "expo-dev-client": "~5.2.0",
         "expo-file-system": "~18.1.10",
@@ -3894,6 +3895,16 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-battery": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/expo-battery/-/expo-battery-9.1.4.tgz",
+      "integrity": "sha512-iPV0ZIXVHfoVoxPwpCSkLKg4TFRexIGO7DLl/kZhXr70mR4IscanJwaWh9yvER80Lu6Q0WSp1afmJPJLu3Fesg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
       }
     },
     "node_modules/expo-build-properties": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "buffer": "^6.0.3",
     "expo": "^53.0.0",
     "expo-av": "~15.1.5",
+    "expo-battery": "~9.1.4",
     "expo-build-properties": "~0.14.6",
     "expo-dev-client": "~5.2.0",
     "expo-file-system": "~18.1.10",


### PR DESCRIPTION
## Summary
- add expo-battery to detect low power mode
- vibrate when backgrounded or in low power
- keep directional cues when vibration mode is enabled
- document new vibration behavior

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687a3b0287ec8326b5caa3df3ec961f3