### PR TITLE
Improve settings layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,11 @@ eas submit --platform ios
 
 ## Usage
 
-1. Open app and toggle the switch to start compass
-2. Point device north to hear notification sound
-3. Configure direction sound frequency in settings
-4. App continues to work when backgrounded or when other apps are open
+1. Open the app to see the compass
+2. Use the grid at the bottom to toggle Learning and Vibration or tap the Frequency panel to choose a cue interval
+3. Swipe up (follow the Advanced arrow) to reveal calibration and pocket offset settings, swipe down to return
+4. Point the device north to hear notification sound
+5. App continues to work when backgrounded or when other apps are open
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- redesign settings with new grid of quick toggles
- display advanced options by swiping up
- add help text for frequency and learning modes
- add haptic feedback to toggle actions
- update README usage instructions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687a6bcbe8b08326865e6afcf44d6c33