### PR TITLE
Enable Android background vibration and audio

### DIFF
--- a/App.js
+++ b/App.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import {
   StyleSheet, View, Text, TouchableOpacity,
   Alert, AppState, Dimensions, ScrollView, Switch, Modal,
-  Vibration
+  Vibration, Platform
 } from 'react-native';
 import { Audio, InterruptionModeIOS, InterruptionModeAndroid } from 'expo-av';
 // import * as Battery from 'expo-battery';
@@ -147,7 +147,11 @@ export default function App() {
   const triggerVibration = async () => {
     try {
       if (isBackground.current) {
-        await BackgroundHaptics.impact('heavy');
+        if (Platform.OS === 'android') {
+          Vibration.vibrate(200);
+        } else {
+          await BackgroundHaptics.impact('heavy');
+        }
       } else {
         await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
       }
@@ -547,8 +551,11 @@ export default function App() {
       isBackground.current = state !== 'active';
       if (state === 'background') {
         setStatus('Running in background');
+        // Keep a silent sound playing so audio remains active on Android
+        startSilentSound();
       } else if (state === 'active') {
         setStatus('Ready');
+        stopSilentSound();
       }
     });
     return () => sub?.remove();

--- a/app.json
+++ b/app.json
@@ -40,7 +40,8 @@
         "backgroundColor": "#FFFFFF"
       },
       "permissions": [
-        "VIBRATE"
+        "VIBRATE",
+        "WAKE_LOCK"
       ]
     },
     "web": {

--- a/background-haptics/src/index.js
+++ b/background-haptics/src/index.js
@@ -1,10 +1,24 @@
-import { Platform } from 'react-native';
+import { Platform, Vibration } from 'react-native';
 import BackgroundHapticsModule from './module';
 
+/**
+ * Trigger a haptic impact even when the app is in the background.
+ *
+ * The custom native module only exists on iOS.  For Android we fall back to
+ * the platform vibration API which works while the app is backgrounded.
+ */
 export function impact(style = 'medium') {
+  if (Platform.OS === 'android') {
+    // Rough mapping of iOS styles to vibration durations
+    const duration = style === 'light' ? 10 : style === 'heavy' ? 40 : 20;
+    Vibration.vibrate(duration);
+    return Promise.resolve();
+  }
+
   if (Platform.OS !== 'ios') {
     return Promise.resolve();
   }
+
   return BackgroundHapticsModule.impact(style);
 }
 


### PR DESCRIPTION
## Summary
- Add Android fallback to custom BackgroundHaptics module using React Native Vibration API
- Ensure vibration handler triggers appropriate feedback on Android when app is backgrounded
- Keep a silent looping sound when app enters background and request WAKE_LOCK permission for Android

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad0480eb788326a32316cddf09df01