### PR TITLE
Enable Android background vibration and service support

### DIFF
--- a/app.json
+++ b/app.json
@@ -40,8 +40,15 @@
         "backgroundColor": "#FFFFFF"
       },
       "permissions": [
-        "VIBRATE"
-      ]
+        "VIBRATE",
+        "FOREGROUND_SERVICE",
+        "WAKE_LOCK"
+      ],
+      "foregroundService": {
+        "notificationTitle": "Sonic Compass active",
+        "notificationBody": "Running in background",
+        "notificationColor": "#0f1a2b"
+      }
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/background-haptics/src/index.js
+++ b/background-haptics/src/index.js
@@ -1,7 +1,16 @@
-import { Platform } from 'react-native';
-import BackgroundHapticsModule from './module';
+import { Platform, Vibration } from 'react-native';
+
+let BackgroundHapticsModule = null;
+if (Platform.OS === 'ios') {
+  BackgroundHapticsModule = require('./module').default;
+}
 
 export function impact(style = 'medium') {
+  if (Platform.OS === 'android') {
+    const durations = { light: 20, medium: 35, heavy: 50 };
+    Vibration.vibrate(durations[style] ?? durations.medium);
+    return Promise.resolve();
+  }
   if (Platform.OS !== 'ios') {
     return Promise.resolve();
   }


### PR DESCRIPTION
## Summary
- support Android background haptics by falling back to the platform vibrator when native module is unavailable
- configure Android foreground service and required permissions for background audio/vibration

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad048275d8832691f6ea5759f6cdb4